### PR TITLE
The swipe event (with a mouse) won't trigger when the element to swipe is an image

### DIFF
--- a/jquery.swipe.js
+++ b/jquery.swipe.js
@@ -55,6 +55,7 @@
 						self.initialXMousePosition = event.pageX;
 						self.initialYMousePosition = event.pageY;
 						//event.stopPropagation();
+						event.preventDefault();
 					},
 					"mouseup": function (event) {
 						var x = event.pageX;


### PR DESCRIPTION
The browser will catch the mousedown event and will not trigger the custom mouseup event, so the swipe will not work.
This fixes the issue.

Tested with Chrome 17.
